### PR TITLE
Add Wedge (Acquistion) angle parameters to Tomo and SubTomo models

### DIFF
--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -257,6 +257,8 @@ class Tomogram(data.Volume):
     def __init__(self, **kwargs):
         data.Volume.__init__(self, **kwargs)
         self._tsId = pwobj.String(kwargs.get('tsId', None))
+        self._acquisitionAngleMax = pwobj.Float(kwargs.get('acquisitionAngleMax', None))
+        self._acquisitionAngleMin = pwobj.Float(kwargs.get('acquisitionAngleMin', None))
 
     def getTsId(self):
         """ Get unique TiltSeries ID, usually retrieved from the
@@ -266,6 +268,18 @@ class Tomogram(data.Volume):
 
     def setTsId(self, value):
         self._tsId.set(value)
+
+    def getAcquisitionAngleMax(self):
+        return self._acquisitionAngleMax.get()
+
+    def getAcquisitionAngleMin(self):
+        return self._acquisitionAngleMin.get()
+
+    def setAcquisitionAngleMax(self, value):
+        self._acquisitionAngleMax.set(value)
+    
+    def setAcquisitionAngleMin(self, value):
+        self._acquisitionAngleMin.set(value)
 
 
 class SetOfTomograms(data.SetOfVolumes):
@@ -486,7 +500,22 @@ class SetOfCoordinates3D(data.EMSet):
         return s
 
 class SubTomogram(data.Volume):
-    pass
+    def __init__(self, **kwargs):
+        data.Volume.__init__(self, **kwargs)
+        self._acquisitionAngleMax = pwobj.Float(kwargs.get('acquisitionAngleMax', None))
+        self._acquisitionAngleMin = pwobj.Float(kwargs.get('acquisitionAngleMin', None))
+
+    def getAcquisitionAngleMax(self):
+        return self._acquisitionAngleMax.get()
+
+    def getAcquisitionAngleMin(self):
+        return self._acquisitionAngleMin.get()
+
+    def setAcquisitionAngleMax(self, value):
+        self._acquisitionAngleMax.set(value)
+    
+    def setAcquisitionAngleMin(self, value):
+        self._acquisitionAngleMin.set(value)
 
 class SetOfSubTomograms(data.SetOfVolumes):
     ITEM_TYPE = SubTomogram

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -257,8 +257,11 @@ class Tomogram(data.Volume):
     def __init__(self, **kwargs):
         data.Volume.__init__(self, **kwargs)
         self._tsId = pwobj.String(kwargs.get('tsId', None))
-        self._acquisitionAngleMax = pwobj.Float(kwargs.get('acquisitionAngleMax', None))
         self._acquisitionAngleMin = pwobj.Float(kwargs.get('acquisitionAngleMin', None))
+        self._acquisitionAngleMax = pwobj.Float(kwargs.get('acquisitionAngleMax', None))
+        self._step = pwobj.Integer(kwargs.get('step'), None)
+        self._axisAngle1 = pwobj.Float(kwargs.get('angleAxis1', None))
+        self._axisAngle2 = pwobj.Float(kwargs.get('angleAxis2', None))
 
     def getTsId(self):
         """ Get unique TiltSeries ID, usually retrieved from the
@@ -280,6 +283,24 @@ class Tomogram(data.Volume):
     
     def setAcquisitionAngleMin(self, value):
         self._acquisitionAngleMin.set(value)
+
+    def getStep(self):
+        return self._step.get()
+
+    def setStep(self, value):
+        return self._step.set(value)
+
+    def getAxisAngle1 (self):
+        return self._axisAngle1.get()
+
+    def setAxisAngle1 (self, value):
+        self._axisAngle1.set(value)
+
+    def getAxisAngle2 (self):
+        return self._axisAngle2.get()
+
+    def setAxisAngles2(self, value):
+        self._axisAngle2.set(value)
 
 
 class SetOfTomograms(data.SetOfVolumes):
@@ -502,8 +523,11 @@ class SetOfCoordinates3D(data.EMSet):
 class SubTomogram(data.Volume):
     def __init__(self, **kwargs):
         data.Volume.__init__(self, **kwargs)
-        self._acquisitionAngleMax = pwobj.Float(kwargs.get('acquisitionAngleMax', None))
         self._acquisitionAngleMin = pwobj.Float(kwargs.get('acquisitionAngleMin', None))
+        self._acquisitionAngleMax = pwobj.Float(kwargs.get('acquisitionAngleMax', None))
+        self._step = pwobj.Integer(kwargs.get('step'), None)
+        self._axisAngle1 = pwobj.Float(kwargs.get('angleAxis1', None))
+        self._axisAngle2 = pwobj.Float(kwargs.get('angleAxis2', None))
 
     def getAcquisitionAngleMax(self):
         return self._acquisitionAngleMax.get()
@@ -516,6 +540,24 @@ class SubTomogram(data.Volume):
     
     def setAcquisitionAngleMin(self, value):
         self._acquisitionAngleMin.set(value)
+
+    def getStep(self):
+        return self._step.get()
+
+    def setStep(self, value):
+        return self._step.set(value)
+
+    def getAxisAngle1 (self):
+        return self._axisAngle1.get()
+
+    def setAxisAngle1 (self, value):
+        self._axisAngle1.set(value)
+
+    def getAxisAngle2 (self):
+        return self._axisAngle2.get()
+
+    def setAxisAngles2(self, value):
+        self._axisAngle2.set(value)
 
 class SetOfSubTomograms(data.SetOfVolumes):
     ITEM_TYPE = SubTomogram

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -259,9 +259,9 @@ class Tomogram(data.Volume):
         self._tsId = pwobj.String(kwargs.get('tsId', None))
         self._acquisitionAngleMin = pwobj.Float(kwargs.get('acquisitionAngleMin', None))
         self._acquisitionAngleMax = pwobj.Float(kwargs.get('acquisitionAngleMax', None))
-        self._step = pwobj.Integer(kwargs.get('step'), None)
-        self._axisAngle1 = pwobj.Float(kwargs.get('angleAxis1', None))
-        self._axisAngle2 = pwobj.Float(kwargs.get('angleAxis2', None))
+        self._step = pwobj.Integer(None)
+        self._angleAxis1 = pwobj.Float(None)
+        self._angleAxis2 = pwobj.Float(None)
 
     def getTsId(self):
         """ Get unique TiltSeries ID, usually retrieved from the
@@ -290,17 +290,17 @@ class Tomogram(data.Volume):
     def setStep(self, value):
         return self._step.set(value)
 
-    def getAxisAngle1 (self):
-        return self._axisAngle1.get()
+    def getAngleAxis1 (self):
+        return self._angleAxis1.get()
 
-    def setAxisAngle1 (self, value):
-        self._axisAngle1.set(value)
+    def setAngleAxis1 (self, value):
+        self._angleAxis1.set(value)
 
-    def getAxisAngle2 (self):
-        return self._axisAngle2.get()
+    def getAngleAxis2 (self):
+        return self._angleAxis2.get()
 
-    def setAxisAngles2(self, value):
-        self._axisAngle2.set(value)
+    def setAngleAxis2(self, value):
+        self._angleAxis2.set(value)
 
 
 class SetOfTomograms(data.SetOfVolumes):
@@ -525,9 +525,9 @@ class SubTomogram(data.Volume):
         data.Volume.__init__(self, **kwargs)
         self._acquisitionAngleMin = pwobj.Float(kwargs.get('acquisitionAngleMin', None))
         self._acquisitionAngleMax = pwobj.Float(kwargs.get('acquisitionAngleMax', None))
-        self._step = pwobj.Integer(kwargs.get('step'), None)
-        self._axisAngle1 = pwobj.Float(kwargs.get('angleAxis1', None))
-        self._axisAngle2 = pwobj.Float(kwargs.get('angleAxis2', None))
+        self._step = pwobj.Integer(None)
+        self._angleAxis1 = pwobj.Float(None)
+        self._angleAxis2 = pwobj.Float(None)
 
     def getAcquisitionAngleMax(self):
         return self._acquisitionAngleMax.get()
@@ -547,17 +547,17 @@ class SubTomogram(data.Volume):
     def setStep(self, value):
         return self._step.set(value)
 
-    def getAxisAngle1 (self):
-        return self._axisAngle1.get()
+    def getAngleAxis1 (self):
+        return self._angleAxis1.get()
 
-    def setAxisAngle1 (self, value):
-        self._axisAngle1.set(value)
+    def setAngleAxis1 (self, value):
+        self._angleAxis1.set(value)
 
-    def getAxisAngle2 (self):
-        return self._axisAngle2.get()
+    def getAngleAxis2 (self):
+        return self._angleAxis2.get()
 
-    def setAxisAngles2(self, value):
-        self._axisAngle2.set(value)
+    def setAngleAxis2(self, value):
+        self._angleAxis2.set(value)
 
 class SetOfSubTomograms(data.SetOfVolumes):
     ITEM_TYPE = SubTomogram

--- a/tomo/protocols/protocol_import_subtomograms.py
+++ b/tomo/protocols/protocol_import_subtomograms.py
@@ -77,11 +77,13 @@ class ProtImportSubTomograms(ProtTomoImportFiles):
     def _insertAllSteps(self):
         self._insertFunctionStep('importSubTomogramsStep',
                                  self.getPattern(),
-                                 self.samplingRate.get())
+                                 self.samplingRate.get(),
+                                 self.acquisitionAngleMax.get(),
+                                 self.acquistionAngleMin.get())
 
     # --------------------------- STEPS functions -----------------------------
 
-    def importSubTomogramsStep(self, pattern, samplingRate):
+    def importSubTomogramsStep(self, pattern, samplingRate, acquisitionAngleMax, acquisitionAngleMin):
         """ Copy images matching the filename pattern
         Register other parameters.
         """
@@ -90,6 +92,8 @@ class ProtImportSubTomograms(ProtTomoImportFiles):
         # Create a Volume template object
         subtomo = SubTomogram()
         subtomo.setSamplingRate(samplingRate)
+        subtomo.setAcquisitionAngleMax(acquisitionAngleMax)
+        subtomo.setAcquisitionAngleMin(acquisitionAngleMin)
 
         imgh = ImageHandler()
 

--- a/tomo/protocols/protocol_import_subtomograms.py
+++ b/tomo/protocols/protocol_import_subtomograms.py
@@ -29,7 +29,7 @@ from os.path import abspath, basename
 
 from pyworkflow.em import ImageHandler
 from pyworkflow.em.data import Transform
-import pyworkflow.protocol.params as params
+from pyworkflow.protocol.params import PointerParam, FloatParam, PathParam
 from pyworkflow.utils.path import createAbsLink
 
 from .protocol_base import ProtTomoImportFiles
@@ -47,23 +47,54 @@ class ProtImportSubTomograms(ProtTomoImportFiles):
     def _defineParams(self, form):
         ProtTomoImportFiles._defineParams(self, form)
 
-        form.addParam('importCoordinates', params.PointerParam,
+        form.addParam('importCoordinates', PointerParam,
                       pointerClass='SetOfCoordinates3D',
                       allowsNull=True,
                       label='Input coordinates 3D',
                       help='Select the coordinates for which the '
                             'subtomograms were extracted.')
-        
-        form.addParam('acquisitionAngleMax', params.FloatParam,
+
+        form.addSection(label='Acquisition Info')
+
+        form.addParam('acquisitionData', PathParam,
+                      label="Acquisition parameters file",
+                      help="File with the acquisition paramenters for every \n"
+                           "subtomogram to import.",
+                      condition="importFrom == 1")
+
+        form.addParam('acquisitionAngleMax', FloatParam,
                       allowsNull=True,
                       default=90,
                       label='Acquisition angle max',
+                      condition="importFrom == 0",
                       help='Enter the positive limit of the acquisition angle')
 
-        form.addParam('acquisitionAngleMin', params.FloatParam,
+        form.addParam('acquisitionAngleMin', FloatParam,
                       allowsNull=True,
                       default=-90,
+                      condition="importFrom == 0",
                       label='Acquisition angle min',
+                      help='Enter the negative limit of the acquisition angle')
+
+        form.addParam('angleAxis1', FloatParam,
+                      allowsNull=True,
+                      default=-90,
+                      condition="importFrom == 0",
+                      label='Angle axis 1',
+                      help='Enter the negative limit of the acquisition angle')
+
+        form.addParam('angleAxis2', FloatParam,
+                      allowsNull=True,
+                      default=-90,
+                      condition="importFrom == 0",
+                      label='Angle Axis 2',
+                      help='Enter the negative limit of the acquisition angle')
+
+        form.addParam('step', FloatParam,
+                      allowsNull=True,
+                      default=-90,
+                      condition="importFrom == 0",
+                      label='Step',
                       help='Enter the negative limit of the acquisition angle')
 
 
@@ -72,7 +103,7 @@ class ProtImportSubTomograms(ProtTomoImportFiles):
         from which the import can be done.
         (usually packages formats such as: xmipp3, eman2, relion...etc.
         """
-        return ['eman2']
+        return ['Manual', 'From file']
 
     def _insertAllSteps(self):
         self._insertFunctionStep('importSubTomogramsStep',

--- a/tomo/protocols/protocol_import_subtomograms.py
+++ b/tomo/protocols/protocol_import_subtomograms.py
@@ -53,6 +53,19 @@ class ProtImportSubTomograms(ProtTomoImportFiles):
                       label='Input coordinates 3D',
                       help='Select the coordinates for which the '
                             'subtomograms were extracted.')
+        
+        form.addParam('acquisitionAngleMax', params.FloatParam,
+                      allowsNull=True,
+                      default=90,
+                      label='Acquisition angle max',
+                      help='Enter the positive limit of the acquisition angle')
+
+        form.addParam('acquisitionAngleMin', params.FloatParam,
+                      allowsNull=True,
+                      default=-90,
+                      label='Acquisition angle min',
+                      help='Enter the negative limit of the acquisition angle')
+
 
     def _getImportChoices(self):
         """ Return a list of possible choices

--- a/tomo/protocols/protocol_import_tomograms.py
+++ b/tomo/protocols/protocol_import_tomograms.py
@@ -30,7 +30,7 @@ from os.path import abspath, basename
 from pyworkflow.em import ImageHandler
 from pyworkflow.em.data import Transform
 from pyworkflow.utils.path import createAbsLink
-from pyworkflow.protocol.params import FloatParam
+from pyworkflow.protocol.params import FloatParam, EnumParam, PathParam
 
 
 from .protocol_base import ProtTomoImportFiles
@@ -48,25 +48,55 @@ class ProtImportTomograms(ProtTomoImportFiles):
     def _defineParams(self, form):
         ProtTomoImportFiles._defineParams(self, form)
 
+        form.addSection(label='Acquisition Info')
+
+        form.addParam('acquisitionData', PathParam,
+                      label="Acquisition parameters file",
+                      help="File with the acquisition paramenters for every \n"
+                            "tomogram to import.",
+                      condition="importFrom == 1")
+
         form.addParam('acquisitionAngleMax', FloatParam,
-                      allowsNull=True,
-                      default=90,
-                      label='Acquisition angle max',
-                      help='Enter the positive limit of the acquisition angle')
+                        allowsNull=True,
+                        default=90,
+                        label='Acquisition angle max',
+                        condition="importFrom == 0",
+                        help='Enter the positive limit of the acquisition angle')
 
         form.addParam('acquisitionAngleMin', FloatParam,
+                        allowsNull=True,
+                        default=-90,
+                        condition="importFrom == 0",
+                        label='Acquisition angle min',
+                        help='Enter the negative limit of the acquisition angle')
+
+        form.addParam('angleAxis1', FloatParam,
                       allowsNull=True,
                       default=-90,
-                      label='Acquisition angle min',
+                      condition="importFrom == 0",
+                      label='Angle axis 1',
+                      help='Enter the negative limit of the acquisition angle')
+
+        form.addParam('angleAxis2', FloatParam,
+                      allowsNull=True,
+                      default=-90,
+                      condition="importFrom == 0",
+                      label='Angle Axis 2',
+                      help='Enter the negative limit of the acquisition angle')
+
+        form.addParam('step', FloatParam,
+                      allowsNull=True,
+                      default=-90,
+                      condition="importFrom == 0",
+                      label='Step',
                       help='Enter the negative limit of the acquisition angle')
 
 
     def _getImportChoices(self):
         """ Return a list of possible choices
         from which the import can be done.
-        (usually packages formats such as: xmipp3, eman2, relion...etc.
         """
-        return ['eman2']
+        return ['Manual', 'From file']
 
     def _insertAllSteps(self):
         self._insertFunctionStep('importTomogramsStep',

--- a/tomo/protocols/protocol_import_tomograms.py
+++ b/tomo/protocols/protocol_import_tomograms.py
@@ -30,6 +30,7 @@ from os.path import abspath, basename
 from pyworkflow.em import ImageHandler
 from pyworkflow.em.data import Transform
 from pyworkflow.utils.path import createAbsLink
+from pyworkflow.protocol.params import FloatParam
 
 
 from .protocol_base import ProtTomoImportFiles
@@ -43,6 +44,22 @@ class ProtImportTomograms(ProtTomoImportFiles):
 
     def __init__(self, **args):
         ProtTomoImportFiles.__init__(self, **args)
+
+    def _defineParams(self, form):
+        ProtTomoImportFiles._defineParams(self, form)
+
+        form.addParam('acquisitionAngleMax', FloatParam,
+                      allowsNull=True,
+                      default=90,
+                      label='Acquisition angle max',
+                      help='Enter the positive limit of the acquisition angle')
+
+        form.addParam('acquisitionAngleMin', FloatParam,
+                      allowsNull=True,
+                      default=-90,
+                      label='Acquisition angle min',
+                      help='Enter the negative limit of the acquisition angle')
+
 
     def _getImportChoices(self):
         """ Return a list of possible choices

--- a/tomo/protocols/protocol_import_tomograms.py
+++ b/tomo/protocols/protocol_import_tomograms.py
@@ -71,12 +71,14 @@ class ProtImportTomograms(ProtTomoImportFiles):
     def _insertAllSteps(self):
         self._insertFunctionStep('importTomogramsStep',
                                  self.getPattern(),
-                                 self.samplingRate.get())
+                                 self.samplingRate.get(),
+                                 self.acquisitionAngleMax.get(),
+                                 self.acquisitionAngleMin.get())
 
 
     # --------------------------- STEPS functions -----------------------------
 
-    def importTomogramsStep(self, pattern, samplingRate):
+    def importTomogramsStep(self, pattern, samplingRate, acquistionAngleMax, acquistionAngleMin):
         """ Copy images matching the filename pattern
         Register other parameters.
         """
@@ -85,6 +87,8 @@ class ProtImportTomograms(ProtTomoImportFiles):
         # Create a Volume template object
         tomo = Tomogram()
         tomo.setSamplingRate(samplingRate)
+        tomo.setAcquisitionAngleMax(acquistionAngleMax)
+        tomo.setAcquisitionAngleMin(acquistionAngleMin)
 
         imgh = ImageHandler()
 

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -33,6 +33,7 @@ from pyworkflow.em import Domain, CTFModel
 from tomo.tests import DataSet
 from tomo.objects import SetOfTiltSeriesM, SetOfTiltSeries
 import tomo.protocols
+import inspect
 
 
 class TestTomoBase(BaseTest):
@@ -229,7 +230,7 @@ class TestTomoImportTomogramsProtocols(BaseTest):
              filesPath=self.dataPath,
              filesPattern='',
              acquisitionAngleMax=40,
-             acquisitionAngleMin=-40
+             acquisitionAngleMin=-40,
              samplingRate=1.35)
          self.launchProtocol(protImport)
          return protImport
@@ -245,7 +246,8 @@ class TestTomoImportTomogramsProtocols(BaseTest):
          self.assertIsNotNone(protImport.outputTomogram.getYDim() == 1024,
                              "There was a problem with Import Tomograms protocol")
 
-        self.assertTrue(protImport.outputTomogram.g)
+         self.assertTrue(protImport.outputTomogram.getAcquisitionAngleMax() == 40, "There was a problem with the aquisition angle max")
+         self.assertTrue(protImport.outputTomogram.getAcquisitionAngleMin() == -40, "There was a problem with the aquisition angle min")
 
 
 

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -228,6 +228,8 @@ class TestTomoImportTomogramsProtocols(BaseTest):
              tomo.protocols.ProtImportTomograms,
              filesPath=self.dataPath,
              filesPattern='',
+             acquisitionAngleMax=40,
+             acquisitionAngleMin=-40
              samplingRate=1.35)
          self.launchProtocol(protImport)
          return protImport
@@ -243,8 +245,8 @@ class TestTomoImportTomogramsProtocols(BaseTest):
          self.assertIsNotNone(protImport.outputTomogram.getYDim() == 1024,
                              "There was a problem with Import Tomograms protocol")
 
+        self.assertTrue(protImport.outputTomogram.g)
 
-         return protImport
 
 
 class TestTomoPreprocessing(BaseTest):


### PR DESCRIPTION
Added parameters to both forms, models and Tomo test
Parameters added: AcquisitionAngleMax/Min, Step, Angle axis 1, Angle axis 2.

Added option to load these parameters from a .txt file.
This file should have the following format:
`filename.em acAngleMin acAngleMax step angleAxis1 angleAxis2`